### PR TITLE
fix: reset expectedJoinEvents when we are exiting the coregion

### DIFF
--- a/lib/src/definitions/co_region_definition.dart
+++ b/lib/src/definitions/co_region_definition.dart
@@ -4,6 +4,8 @@
 
 // part  'co_region_definition.dart';
 
+import 'package:meta/meta.dart';
+
 import '../transitions/join_transition.dart';
 import '../types.dart';
 import 'state_definition.dart';
@@ -22,6 +24,16 @@ class CoRegionDefinition<S extends State> extends StateDefinition<S> {
 
     /// true if all events have been received.
     return expectedJoinEvents.values.every((element) => element == true);
+  }
+
+  /// Clean up [expectedJoinEvents] when we exit the coregion.
+  @override
+  @mustCallSuper
+  Future<void> internalOnExit(Type fromState, Event? event) async {
+    await super.internalOnExit(fromState, event);
+    for (final key in expectedJoinEvents.keys) {
+      expectedJoinEvents[key] = false;
+    }
   }
 
   /// default implementation.

--- a/lib/src/definitions/state_definition.dart
+++ b/lib/src/definitions/state_definition.dart
@@ -102,10 +102,10 @@ class StateDefinition<S extends State> {
 
   /// This method is called when we exit this state to give the
   /// [StateDefinition] a chance to do any internal cleanup.
-  /// If you must call [_onExit] so that we can call the user
+  /// If you must call [internalOnExit] so that we can call the user
   /// defined [onExit] method.
   @mustCallSuper
-  Future<void> _onExit(Type fromState, Event? event) async {
+  Future<void> internalOnExit(Type fromState, Event? event) async {
     try {
       log('FSM onExit called for $stateType due to ${event.runtimeType}');
       await onExit(fromState, event);
@@ -414,7 +414,7 @@ Future<void> onEnter(StateDefinition sd, Type toState, Event? event) async {
 }
 
 Future<void> onExit(StateDefinition sd, Type fromState, Event? event) async {
-  await sd._onExit(fromState, event);
+  await sd.internalOnExit(fromState, event);
 }
 
 void addCoRegion<CO extends State>(

--- a/test/fork_join_test.dart
+++ b/test/fork_join_test.dart
@@ -40,8 +40,7 @@ void main() {
     // go into the coregion again.
     fsm.applyEvent(Fork());
     await fsm.complete;
-    // FAILS HERE with EndState->VirtualRoot
-    // We should still be in the coregion.
+    // if the coregion does not reset the join events, we will fail here.
     expect(await fsm.isInState<Coregion>(), equals(true),
         reason: fsm.stateOfMind.toString());
     fsm.applyEvent(ResolveStateB());

--- a/test/fork_join_test.dart
+++ b/test/fork_join_test.dart
@@ -1,0 +1,70 @@
+import 'package:fsm2/fsm2.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late StateMachine fsm;
+
+  /// https://github.com/onepub-dev/fsm2/issues/18
+  test('test fork join with sideEffect', () async {
+    fsm = await StateMachine.create(
+        (g) => g
+          ..initialState<CanFork>()
+          ..state<CanFork>((b) => b.onFork<Fork>(
+              (b) => b
+                ..target<StateA>()
+                ..target<StateB>(),
+              sideEffect: (e) async => fsm.applyEvent(ResolveStateA())))
+          ..coregion<Coregion>((b) => b
+            ..state<StateA>((b) => b.onJoin<ResolveStateA, EndState>())
+            ..state<StateB>((b) => b.onJoin<ResolveStateB, EndState>()))
+          ..state<EndState>((b) => b.on<GoBackToStart, CanFork>()),
+        production: true);
+    // go into the coregion
+    fsm.applyEvent(Fork());
+    await fsm.complete;
+    // we are now in the coregion
+    expect(await fsm.isInState<Coregion>(), equals(true),
+        reason: fsm.stateOfMind.toString());
+    // StateA is already resolved by the sideEffect.
+    // StateB is not resolved yet.
+    fsm.applyEvent(ResolveStateB());
+    await fsm.complete;
+    // we are now at the end state.
+    expect(await fsm.isInState<EndState>(), equals(true),
+        reason: fsm.stateOfMind.toString());
+    // go back to the start.
+    fsm.applyEvent(GoBackToStart());
+    await fsm.complete;
+    expect(await fsm.isInState<CanFork>(), equals(true),
+        reason: fsm.stateOfMind.toString());
+    // go into the coregion again.
+    fsm.applyEvent(Fork());
+    await fsm.complete;
+    // FAILS HERE with EndState->VirtualRoot
+    // We should still be in the coregion.
+    expect(await fsm.isInState<Coregion>(), equals(true),
+        reason: fsm.stateOfMind.toString());
+    fsm.applyEvent(ResolveStateB());
+    await fsm.complete;
+    expect(await fsm.isInState<EndState>(), equals(true),
+        reason: fsm.stateOfMind.toString());
+  });
+}
+
+class CanFork extends State {}
+
+class Fork extends Event {}
+
+class Coregion extends State {}
+
+class StateA extends State {}
+
+class ResolveStateA extends Event {}
+
+class StateB extends State {}
+
+class ResolveStateB extends Event {}
+
+class EndState extends State {}
+
+class GoBackToStart extends Event {}


### PR DESCRIPTION
Otherwise we lose the requirement that all coregion states must transition out before we leave the coregion).